### PR TITLE
Fix Event Processing Bug and Add Broker Method in HTTP-Core

### DIFF
--- a/packages/events/broker.ts
+++ b/packages/events/broker.ts
@@ -146,7 +146,7 @@ export class Broker {
     return broker.request<R>(...args);
   }
 
-  public pipeTo(brokerId: string, sourceEvent: EventType, targetEvent: EventType, bidirectional: boolean = true): Noop {
+  public pipeTo(brokerId: string, sourceEvent: EventType, targetEvent: EventType): Noop {
     const broker = this._connections.get(brokerId);
     if (!broker) {
       throw new Error(`Broker ${brokerId} not found`);
@@ -156,16 +156,8 @@ export class Broker {
       broker.emit(targetEvent, data);
     });
 
-    let brokerOff: Noop = () => {};
-    if (bidirectional) {
-      brokerOff = broker.on(sourceEvent, (data) => {
-        this.emit(targetEvent, data);
-      });
-    }
-
     return () => {
       off();
-      brokerOff();
     };
   }
   public connectAll(brokers: Broker[]): Noop {

--- a/packages/http/adapter/http.adapter.ts
+++ b/packages/http/adapter/http.adapter.ts
@@ -13,10 +13,10 @@ export class HttpAdapter implements Adapter<'http'> {
   private _transport: ServerTransport;
   private readonly _incomingServer: IncomingRequestServer;
   protected _events: HttpEventCore;
-  protected broker: Broker;
+  protected _broker: Broker;
   constructor() {
-    this.broker = new Broker('http');
-    this._events = new HttpEventCore(this.broker.channel('http'));
+    this._broker = new Broker('http');
+    this._events = new HttpEventCore(this._broker.channel('http'));
     this._incomingServer = new IncomingRequestServer(this._events);
     this._events.once('options', this.init.bind(this));
   }

--- a/packages/http/http-core.ts
+++ b/packages/http/http-core.ts
@@ -45,6 +45,9 @@ export class HttpCore extends HttpAdapter {
     this._events.emit('options', options);
     this._plugins.setupMiddleware(this);
   }
+  get broker() {
+    return this._broker;
+  }
 
   get id() {
     return this.broker.id;

--- a/packages/http/interface/http-context.interface.ts
+++ b/packages/http/interface/http-context.interface.ts
@@ -1,4 +1,4 @@
-import { AdapterContext, RequestMethod } from '@gland/common';
+import { AdapterContext, RequestMethod, type EventType } from '@gland/common';
 import { Dictionary, HttpExceptionOptions, HttpStatus, Maybe, Noop } from '@medishn/toolkit';
 import { HttpHeaderName, HttpHeaderValue, HttpHeaders } from './headers.interface';
 
@@ -187,4 +187,6 @@ export interface HttpContext extends AdapterContext<'http'> {
   end(cb?: Noop): this;
   end(chunk: any, cb?: Noop): this;
   end(chunk: any, encoding: BufferEncoding, cb?: Noop): this;
+
+  emit<D>(event: EventType, data?: D): void;
 }


### PR DESCRIPTION
# PR Template

## Description
This PR introduces two important updates:
1. **Fixed bug in event processing**: A bug was identified where string items were not being correctly converted to the corresponding item type in the `process` method. This issue was resolved, ensuring that string items are properly processed.
2. **Broker and emit method additions to `http-core`**: A new method was added to the `http-core` broker, allowing it to return the main HTTP broker. Additionally, an `emit` method was added to the `http-context`, enabling better interaction with event-based communication in the HTTP layer.

## Type of Change
<!-- Check at least one that applies -->
Please check the option(s) that apply to this PR:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Build or CI/CD related changes
- [ ] Performance improvement
- [ ] Other (please describe):

## Checklist
<!-- Check the items that apply to this PR -->
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the event-driven architecture of Gland
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made necessary documentation updates
- [x] My changes generate no new warnings or errors
- [ ] I have updated examples if applicable
- [x] My branch is up-to-date with the base branch

**Breaking Changes?**  
- [ ] Yes (please describe the impact and migration path)
- [x] No  

**Documentation Impact**  
- [ ] Requires updates to event flow diagrams  
- [ ] New channel API docs needed  
- [x] No changes required  

## Current Behavior
Currently I created a broker in @gland/core (actually broker @gland/core) to communicate with http which required the main http broker for which I added the broker method. But to process the events and return them the queue did not work properly. And when processing and error path.splite not function returns. Because when processing in the circular-deque file it returns a number and in the storeItem function it is not stored correctly and is converted to a number. (Not correct behavior). And it encounters an error.

## New Behavior
With these changes, to return the original Http broker, just call the broker method. Also, events sent to the queue will be processed correctly.
