### PR TITLE
chore: add default ctx to data if not defined in HttpContext.emit

### DIFF
--- a/examples/very-simple.ts
+++ b/examples/very-simple.ts
@@ -7,7 +7,7 @@ class UserController {
   @Get('/')
   createUser(ctx: HttpContext) {
     const data = 1;
-    ctx.emit('user:created', { data, ctx });
+    ctx.emit('user:created', { data });
   }
 }
 
@@ -17,7 +17,7 @@ class UserChannel {
   async handleUserCreated(payload: { ctx: HttpContext; data: any }) {
     const body = payload.data;
     const ctx = payload.ctx;
-    ctx.emit('@response:send', { ctx, body });
+    ctx.emit('@response:send', { body });
   }
 }
 

--- a/packages/http/context/http-context.ts
+++ b/packages/http/context/http-context.ts
@@ -253,6 +253,8 @@ export class HttpServerContext extends Context<'http'> implements HttpContext {
   }
 
   public emit<D>(event: EventType, data?: D) {
+    if (data) data["ctx"] = data["ctx"] || this;
+
     const type = event.startsWith('@') ? event.split('@')[1] : event;
     const broker = this._events['_channel']['broker'] as Broker;
     const channels = this.state.channel;


### PR DESCRIPTION
# PR Request

## Description

chore: add default ctx to data if not defined in HttpContext.emit

## Type of Change

<!-- Check at least one that applies -->

Please check the option(s) that apply to this PR:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Build or CI/CD related changes
- [ ] Performance improvement
- [ ] Other (please describe):

## Checklist

<!-- Check the items that apply to this PR -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the event-driven architecture of Gland
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made necessary documentation updates
- [x] My changes generate no new warnings or errors
- [x] I have updated examples if applicable
- [x] My branch is up-to-date with the base branch

**Breaking Changes?**

- [ ] Yes (please describe the impact and migration path)
- [x] No

**Documentation Impact**

- [ ] Requires updates to event flow diagrams
- [ ] New channel API docs needed
- [x] No changes required

## Current Behavior

Before this change, the server would crash if the user omitted the ctx in their body of HttpContext.emit, saying the ctx was undefined.

## New Behavior

Now, if the user does this, for example:
```javascript
ctx.emit('user:created', { data });
```

instead of this:
```javascript
ctx.emit('user:created', { data, ctx });
```

The server will run without any issues.

**Additional Information**

<!--Provide any other relevant details about this PR, such as implementation considerations, limitations, or future work. -->
None
